### PR TITLE
Feature 1675: Better default for file selection dialog for texture image

### DIFF
--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -38,6 +38,7 @@
 
 #include <Base/Parameter.h>
 #include <App/Application.h>
+#include <App/Document.h>
 
 #include "FileDialog.h"
 #include "MainWindow.h"
@@ -521,11 +522,24 @@ void FileChooser::setFileName( const QString& s )
  */
 void FileChooser::chooseFile()
 {
+    QString prechosenDirectory = lineEdit->text();
+    if (prechosenDirectory.isEmpty()) {
+        App::Document* const doc = App::GetApplication().getActiveDocument();
+        const QString filename = QString::fromStdString(doc->FileName.getStrValue());
+
+        // if the document has no filename yet, start browsing in the users home directory
+        if (!filename.isEmpty()) {
+            prechosenDirectory = filename;
+        } else {
+            prechosenDirectory = QDir::homePath();
+        }
+    }
+
     QString fn;
     if ( mode() == File )
-        fn = QFileDialog::getOpenFileName( this, tr( "Select a file" ), lineEdit->text(), _filter );
+        fn = QFileDialog::getOpenFileName( this, tr( "Select a file" ), prechosenDirectory, _filter );
     else
-        fn = QFileDialog::getExistingDirectory( this, tr( "Select a directory" ), lineEdit->text() );
+        fn = QFileDialog::getExistingDirectory( this, tr( "Select a directory" ), prechosenDirectory );
 
     if (!fn.isEmpty()) {
         lineEdit->setText(fn);

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -38,7 +38,6 @@
 
 #include <Base/Parameter.h>
 #include <App/Application.h>
-#include <App/Document.h>
 
 #include "FileDialog.h"
 #include "MainWindow.h"
@@ -524,15 +523,7 @@ void FileChooser::chooseFile()
 {
     QString prechosenDirectory = lineEdit->text();
     if (prechosenDirectory.isEmpty()) {
-        App::Document* const doc = App::GetApplication().getActiveDocument();
-        const QString filename = QString::fromStdString(doc->FileName.getStrValue());
-
-        // if the document has no filename yet, start browsing in the users home directory
-        if (!filename.isEmpty()) {
-            prechosenDirectory = filename;
-        } else {
-            prechosenDirectory = QDir::homePath();
-        }
+        prechosenDirectory = FileDialog::getWorkingDirectory();
     }
 
     QString fn;
@@ -543,6 +534,7 @@ void FileChooser::chooseFile()
 
     if (!fn.isEmpty()) {
         lineEdit->setText(fn);
+        FileDialog::setWorkingDirectory(fn);
         fileNameSelected(fn);
     }
 }


### PR DESCRIPTION
By default, use the path of the currently open file. If the file is still new, default to the user's home directory.

This fix is not specific to the file selection dialog for the texture image, but should work for all file dialogs opened from the property table.

Testing done: Compiles, runs and handles the cases mentioned above.