### PR TITLE
 Reuse projection settings from an existing view when creating new part/draft views

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -2123,7 +2123,7 @@ def getrgb(color,testbw=True):
                 col = "#000000"
     return col
 
-def makeDrawingView(obj,page,lwmod=None,tmod=None):
+def makeDrawingView(obj,page,lwmod=None,tmod=None,otherProjection=None):
     '''
     makeDrawingView(object,page,[lwmod,tmod]) - adds a View of the given object to the
     given page. lwmod modifies lineweights (in percent), tmod modifies text heights
@@ -2143,12 +2143,27 @@ def makeDrawingView(obj,page,lwmod=None,tmod=None):
         viewobj = FreeCAD.ActiveDocument.addObject("Drawing::FeatureViewPython","View"+obj.Name)
         _DrawingView(viewobj)
         page.addObject(viewobj)
-        if hasattr(page.ViewObject,"HintScale"):
-            viewobj.Scale = page.ViewObject.HintScale
-        if hasattr(page.ViewObject,"HintOffsetX"):
-            viewobj.X = page.ViewObject.HintOffsetX
-        if hasattr(page.ViewObject,"HintOffsetY"):
-            viewobj.Y = page.ViewObject.HintOffsetY
+        if (otherProjection):
+            FreeCAD.Console.PrintWarning("using otherProjection")
+            if hasattr(otherProjection,"Scale"):
+                FreeCAD.Console.PrintWarning(otherProjection.Scale)
+                viewobj.Scale = otherProjection.Scale
+            if hasattr(otherProjection,"X"):
+                viewobj.X = otherProjection.X
+            if hasattr(otherProjection,"Y"):
+                viewobj.Y = otherProjection.Y
+            if hasattr(otherProjection,"Rotation"):
+                viewobj.Rotation = otherProjection.Rotation
+            if hasattr(otherProjection,"Direction"):
+                FreeCAD.Console.PrintWarning(otherProjection.Direction)
+                viewobj.Direction = otherProjection.Direction
+        else:
+            if hasattr(page.ViewObject,"HintScale"):
+                viewobj.Scale = page.ViewObject.HintScale
+            if hasattr(page.ViewObject,"HintOffsetX"):
+                viewobj.X = page.ViewObject.HintOffsetX
+            if hasattr(page.ViewObject,"HintOffsetY"):
+                viewobj.Y = page.ViewObject.HintOffsetY
         viewobj.Source = obj
         if lwmod: viewobj.LineweightModifier = lwmod
         if tmod: viewobj.TextModifier = tmod

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -2144,9 +2144,7 @@ def makeDrawingView(obj,page,lwmod=None,tmod=None,otherProjection=None):
         _DrawingView(viewobj)
         page.addObject(viewobj)
         if (otherProjection):
-            FreeCAD.Console.PrintWarning("using otherProjection")
             if hasattr(otherProjection,"Scale"):
-                FreeCAD.Console.PrintWarning(otherProjection.Scale)
                 viewobj.Scale = otherProjection.Scale
             if hasattr(otherProjection,"X"):
                 viewobj.X = otherProjection.X
@@ -2155,7 +2153,6 @@ def makeDrawingView(obj,page,lwmod=None,tmod=None,otherProjection=None):
             if hasattr(otherProjection,"Rotation"):
                 viewobj.Rotation = otherProjection.Rotation
             if hasattr(otherProjection,"Direction"):
-                FreeCAD.Console.PrintWarning(otherProjection.Direction)
                 viewobj.Direction = otherProjection.Direction
         else:
             if hasattr(page.ViewObject,"HintScale"):

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -3152,10 +3152,8 @@ class Drawing(Modifier):
                 self.page = self.createDefaultPage()
             otherProjection = None
             for obj in sel:
-                FreeCAD.Console.PrintWarning(obj)
                 if obj.isDerivedFrom("Drawing::FeatureView"):
                     otherProjection = obj
-            FreeCAD.Console.PrintWarning(otherProjection)
             sel.reverse() 
             for obj in sel:
                 if obj.ViewObject.isVisible():
@@ -3164,7 +3162,7 @@ class Drawing(Modifier):
                     #oldobj = self.page.getObject(name)
                     #if oldobj: 
                     #    self.doc.removeObject(oldobj.Name)
-                    Draft.makeDrawingView(obj,self.page,None,None,otherProjection)
+                    Draft.makeDrawingView(obj,self.page,otherProjection=otherProjection)
             self.doc.recompute()
 
     def createDefaultPage(self):

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -3150,6 +3150,12 @@ class Drawing(Modifier):
                         self.page = obj
             if not self.page:
                 self.page = self.createDefaultPage()
+            otherProjection = None
+            for obj in sel:
+                FreeCAD.Console.PrintWarning(obj)
+                if obj.isDerivedFrom("Drawing::FeatureView"):
+                    otherProjection = obj
+            FreeCAD.Console.PrintWarning(otherProjection)
             sel.reverse() 
             for obj in sel:
                 if obj.ViewObject.isVisible():
@@ -3158,7 +3164,7 @@ class Drawing(Modifier):
                     #oldobj = self.page.getObject(name)
                     #if oldobj: 
                     #    self.doc.removeObject(oldobj.Name)
-                    Draft.makeDrawingView(obj,self.page)
+                    Draft.makeDrawingView(obj,self.page,None,None,otherProjection)
             self.doc.recompute()
 
     def createDefaultPage(self):

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -3140,23 +3140,30 @@ class Drawing(Modifier):
             self.page = self.createDefaultPage()
         else:
             self.page = None
+            # if the user selected a page, put the objects on that page
             for obj in sel:
                 if obj.isDerivedFrom("Drawing::FeaturePage"):
                     self.page = obj
-                    sel.pop(sel.index(obj))
+                    break
             if not self.page:
+                # no page selected, default to the first page in the document
                 for obj in self.doc.Objects:
                     if obj.isDerivedFrom("Drawing::FeaturePage"):
                         self.page = obj
+                        break
             if not self.page:
+                # no page in the document, create a default page.
                 self.page = self.createDefaultPage()
             otherProjection = None
+            # if an existing projection is selected, reuse its projection properties
             for obj in sel:
                 if obj.isDerivedFrom("Drawing::FeatureView"):
                     otherProjection = obj
+                    break
             sel.reverse() 
             for obj in sel:
-                if obj.ViewObject.isVisible():
+                if ( obj.ViewObject.isVisible() and not obj.isDerivedFrom("Drawing::FeatureView")
+                        and not obj.isDerivedFrom("Drawing::FeaturePage") ):
                     name = 'View'+obj.Name
                     # no reason to remove the old one...
                     #oldobj = self.page.getObject(name)

--- a/src/Mod/Drawing/Gui/Command.cpp
+++ b/src/Mod/Drawing/Gui/Command.cpp
@@ -293,22 +293,14 @@ void CmdDrawingNewView::activated(int iMsg)
     if (!selectedProjections.empty()) {
         const Drawing::FeatureView* const myView = dynamic_cast<Drawing::FeatureView*>(selectedProjections.front());
 
-        const App::PropertyFloat* const propX = dynamic_cast<App::PropertyFloat*>(myView->getPropertyByName("X"));
-        if (propX) {
-            newX = propX->getValue();
-        }
-        const App::PropertyFloat* const propY = dynamic_cast<App::PropertyFloat*>(myView->getPropertyByName("Y"));
-        if (propY) {
-            newY = propY->getValue();
-        }
-        const App::PropertyFloat* const propScale = dynamic_cast<App::PropertyFloat*>(myView->getPropertyByName("Scale"));
-        if (propScale) {
-            newScale = propScale->getValue();
-        }
-        const App::PropertyFloat* const propRotation = dynamic_cast<App::PropertyFloat*>(myView->getPropertyByName("Rotation"));
-        if (propRotation) {
-            newRotation = propRotation->getValue();
-        }
+        newX = myView->X.getValue();
+        newY = myView->Y.getValue();
+        newScale = myView->Scale.getValue();
+        newRotation = myView->Rotation.getValue();
+
+        // The "Direction" property does not belong to Drawing::FeatureView, but to one of the
+        // many child classes that are projecting objects into the drawing. Therefore, we get the
+        // property by name.
         const App::PropertyVector* const propDirection = dynamic_cast<App::PropertyVector*>(myView->getPropertyByName("Direction"));
         if (propDirection) {
             newDirection = propDirection->getValue();

--- a/src/Mod/Drawing/Gui/Command.cpp
+++ b/src/Mod/Drawing/Gui/Command.cpp
@@ -22,6 +22,8 @@
 
 #include <vector>
 
+#include <App/PropertyGeo.h>
+
 #include <Gui/Action.h>
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
@@ -282,6 +284,37 @@ void CmdDrawingNewView::activated(int iMsg)
         }
     }
 
+    const std::vector<App::DocumentObject*> selectedProjections = getSelection().getObjectsOfType(Drawing::FeatureView::getClassTypeId());
+    float newX = 10.0;
+    float newY = 10.0;
+    float newScale = 1.0;
+    float newRotation = 0.0;
+    Base::Vector3d newDirection(0.0, 0.0, 1.0);
+    if (!selectedProjections.empty()) {
+        const Drawing::FeatureView* const myView = dynamic_cast<Drawing::FeatureView*>(selectedProjections.front());
+
+        const App::PropertyFloat* const propX = dynamic_cast<App::PropertyFloat*>(myView->getPropertyByName("X"));
+        if (propX) {
+            newX = propX->getValue();
+        }
+        const App::PropertyFloat* const propY = dynamic_cast<App::PropertyFloat*>(myView->getPropertyByName("Y"));
+        if (propY) {
+            newY = propY->getValue();
+        }
+        const App::PropertyFloat* const propScale = dynamic_cast<App::PropertyFloat*>(myView->getPropertyByName("Scale"));
+        if (propScale) {
+            newScale = propScale->getValue();
+        }
+        const App::PropertyFloat* const propRotation = dynamic_cast<App::PropertyFloat*>(myView->getPropertyByName("Rotation"));
+        if (propRotation) {
+            newRotation = propRotation->getValue();
+        }
+        const App::PropertyVector* const propDirection = dynamic_cast<App::PropertyVector*>(myView->getPropertyByName("Direction"));
+        if (propDirection) {
+            newDirection = propDirection->getValue();
+        }
+    }
+
     std::string PageName = pages.front()->getNameInDocument();
 
     openCommand("Create view");
@@ -289,10 +322,11 @@ void CmdDrawingNewView::activated(int iMsg)
         std::string FeatName = getUniqueObjectName("View");
         doCommand(Doc,"App.activeDocument().addObject('Drawing::FeatureViewPart','%s')",FeatName.c_str());
         doCommand(Doc,"App.activeDocument().%s.Source = App.activeDocument().%s",FeatName.c_str(),(*it)->getNameInDocument());
-        doCommand(Doc,"App.activeDocument().%s.Direction = (0.0,0.0,1.0)",FeatName.c_str());
-        doCommand(Doc,"App.activeDocument().%s.X = 10.0",FeatName.c_str());
-        doCommand(Doc,"App.activeDocument().%s.Y = 10.0",FeatName.c_str());
-        doCommand(Doc,"App.activeDocument().%s.Scale = 1.0",FeatName.c_str());
+        doCommand(Doc,"App.activeDocument().%s.Direction = (%e,%e,%e)",FeatName.c_str(), newDirection.x, newDirection.y, newDirection.z);
+        doCommand(Doc,"App.activeDocument().%s.X = %e",FeatName.c_str(), newX);
+        doCommand(Doc,"App.activeDocument().%s.Y = %e",FeatName.c_str(), newY);
+        doCommand(Doc,"App.activeDocument().%s.Scale = %e",FeatName.c_str(), newScale);
+        doCommand(Doc,"App.activeDocument().%s.Rotation = %e",FeatName.c_str(), newRotation);
         doCommand(Doc,"App.activeDocument().%s.addObject(App.activeDocument().%s)",PageName.c_str(),FeatName.c_str());
     }
     updateActive();


### PR DESCRIPTION
Select a part or draft object and a view on a drawing page, then create a new view of the part/draft object using the "Draft->Drawing" or "Drawing->Insert view in drawing" commands. The new view will have the same projection properties as the selected view.

This is useful when you have created orthographic views of an object and want to quickly add the dimensions you made in the 3d space to the drawing page.