### PR TITLE
Fixes for high DPI monitors

### DIFF
--- a/src/Gui/propertyeditor/PropertyItemDelegate.cpp
+++ b/src/Gui/propertyeditor/PropertyItemDelegate.cpp
@@ -47,7 +47,6 @@ PropertyItemDelegate::~PropertyItemDelegate()
 QSize PropertyItemDelegate::sizeHint(const QStyleOptionViewItem & option, const QModelIndex & index) const
 {
     QSize size = QItemDelegate::sizeHint(option, index);
-    size.setHeight(20);
     return size;
 }
 

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -542,7 +542,8 @@ class DraftToolBar:
         
     def setupTray(self):
         "sets draft tray buttons up"
-
+        p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/General")
+        isize = p.GetInt("ToolbarIconSize",24)
         self.wplabel = self._pushbutton("wplabel", self.toptray, icon='Draft_SelectPlane',hide=False,width=120)
         defaultWP = Draft.getParam("defaultWP",0)
         if defaultWP == 1:
@@ -553,20 +554,26 @@ class DraftToolBar:
             self.wplabel.setText("Side")
         else:
             self.wplabel.setText("Auto")
-        self.constrButton = self._pushbutton("constrButton", self.toptray, hide=False, icon='Draft_Construction',width=22, checkable=True)
+        self.constrButton = self._pushbutton("constrButton", self.toptray, hide=False, icon='Draft_Construction',width=isize, checkable=True)
         self.constrColor = QtGui.QColor(self.paramconstr)
-        self.colorButton = self._pushbutton("colorButton",self.bottomtray, hide=False,width=22)
-        self.colorPix = QtGui.QPixmap(16,16)
+        self.colorButton = self._pushbutton("colorButton",self.bottomtray, hide=False,width=isize)
+        self.colorPix = QtGui.QPixmap(isize-6,isize-6)
         self.colorPix.fill(self.color)
         self.colorButton.setIcon(QtGui.QIcon(self.colorPix))
-        self.facecolorButton = self._pushbutton("facecolorButton",self.bottomtray, hide=False,width=22)
-        self.facecolorPix = QtGui.QPixmap(16,16)
+        self.facecolorButton = self._pushbutton("facecolorButton",self.bottomtray, hide=False,width=isize)
+        self.facecolorPix = QtGui.QPixmap(isize-6,isize-6)
         self.facecolorPix.fill(self.facecolor)
         self.facecolorButton.setIcon(QtGui.QIcon(self.facecolorPix))
-        self.widthButton = self._spinbox("widthButton", self.bottomtray, val=self.linewidth,hide=False,size=(50,22))
+        screenWidth = QtGui.QApplication.desktop().screenGeometry().width()
+        textHeight=22
+        textWidth=50
+        if screenWidth>1920:
+          textHeight=44
+          textWidth=100
+        self.widthButton = self._spinbox("widthButton", self.bottomtray, val=self.linewidth,hide=False,size=(textWidth,textHeight))
         self.widthButton.setSuffix("px")
-        self.fontsizeButton = self._spinbox("fontsizeButton",self.bottomtray, val=self.fontsize,vmax=999, hide=False,double=True,size=(65,22))
-        self.applyButton = self._pushbutton("applyButton", self.toptray, hide=False, icon='Draft_Apply',width=22)
+        self.fontsizeButton = self._spinbox("fontsizeButton",self.bottomtray, val=self.fontsize,vmax=999, hide=False,double=True,size=(textWidth+15,textHeight))
+        self.applyButton = self._pushbutton("applyButton", self.toptray, hide=False, icon='Draft_Apply',width=isize)
 
         QtCore.QObject.connect(self.wplabel,QtCore.SIGNAL("pressed()"),self.selectplane)
         QtCore.QObject.connect(self.colorButton,QtCore.SIGNAL("pressed()"),self.getcol)

--- a/src/Mod/Web/Gui/BrowserView.cpp
+++ b/src/Mod/Web/Gui/BrowserView.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2009 Jürgen Riegel <juergen.riegel@web.de>              *
+ *   Copyright (c) 2009 J?rgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
@@ -49,6 +49,7 @@
 # include <QFileInfo>
 # include <QDesktopServices>
 # include <QMenu>
+# include <QDesktopWidget>
 #endif
 
 #include "BrowserView.h"
@@ -74,6 +75,10 @@ using namespace Gui;
 WebView::WebView(QWidget *parent)
     : QWebView(parent)
 {
+  QRect mainScreenSize = QApplication::desktop()->screenGeometry();
+  if(mainScreenSize.width() > 1920){
+    setTextSizeMultiplier (2.0);
+  }
 }
 
 void WebView::wheelEvent(QWheelEvent *event)


### PR DESCRIPTION
I encountered three bugs while using a high DPI monitor. First, the property editor cells had a fixed height of twenty. Secondly, a small set of the buttons in the Draft toolbar didn't change size as icon size increased. Finally, the start page font size was too small.