### PR TITLE
+ Correct integer absolute rounding

### DIFF
--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -795,7 +795,7 @@ void NavigationStyle::doZoom(SoCamera* camera, float logfactor, const SbVec2f& p
 {
     // something is asking for big zoom factor. This func is made for interactive zooming,
     // where the changes are per mouse move and thus are small.
-    if (abs(logfactor)>4.0)
+    if (std::abs(logfactor)>4.0)
         return;
     SbBool zoomAtCur = this->zoomAtCursor;
     if (zoomAtCur) {

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -1344,7 +1344,7 @@ int Sketch::addAngleAtPointConstraint(
             if (angleErr < -M_PI) angleErr += M_PI*2;
 
             //the autodetector
-            if(abs(angleErr) > M_PI/2 )
+            if(std::abs(angleErr) > M_PI/2 )
                 angleDesire += M_PI;
 
             *angle = angleDesire;
@@ -1747,7 +1747,7 @@ int Sketch::addSnellsLawConstraint(int geoIdRay1, PointPos posRay1,
     
     double n2divn1=*value;
     
-    if ( abs(n2divn1) >= 1.0 ){
+    if ( std::abs(n2divn1) >= 1.0 ){
         *n2 = n2divn1;
         *n1 = 1.0;
     } else {


### PR DESCRIPTION
This patch comes from mac compilation warnings review.

Using std::abs() provides overloaded floating point absolute instead
of cut precision integer on comparisons.